### PR TITLE
Add channel notoraptor to find conda package falcon-cors when building conda package

### DIFF
--- a/conda/ci_build.sh
+++ b/conda/ci_build.sh
@@ -6,6 +6,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels conda-forge
+conda config --add channels notoraptor
 conda config --set channel_priority strict
 
 pip uninstall -y setuptools


### PR DESCRIPTION
Hi @bouthilx !

I created conda packages for `falcon-cors` and uploaded them on my own anaconda channel `notoraptor` (for Python 3.6, 3.7, 2.8 and 3.9): https://anaconda.org/notoraptor/falcon-cors/files

Adding `notoraptor` channel in `ci_build.sh` seems enough to make `conda build` work (I tested it successfully by building orion for Python 3.6 on my computer).

Could you add this commit to your branch, so that we could check if CI succeeds in the main PR ?

PS: If necessary, this is how I built `falcon-cors` conda package. Using `conda skeleton`, it is possible to convert a package from PYPI to conda.

```
# Install Anaconda client and login to channel account where packages will be uploaded
conda install anaconda-client
anaconda login

# Build conda packages from PYPI package

mkdir build
cd build/
conda skeleton pypi falcon-cors

# We must specify conda-forge channel to find falcon package
# Then we build package for each python version we want to support

conda-build -c conda-forge --python 3.6 falcon-cors
anaconda upload /home/notoraptor/anaconda3/conda-bld/linux-64/falcon-cors-1.1.7-py36_0.tar.bz2

conda-build -c conda-forge --python 3.7 falcon-cors
anaconda upload /home/notoraptor/anaconda3/conda-bld/linux-64/falcon-cors-1.1.7-py37_0.tar.bz2 

conda-build -c conda-forge --python 3.8 falcon-cors
anaconda upload /home/notoraptor/anaconda3/conda-bld/linux-64/falcon-cors-1.1.7-py38_0.tar.bz2

conda-build -c conda-forge --python 3.9 falcon-cors
anaconda upload /home/notoraptor/anaconda3/conda-bld/linux-64/falcon-cors-1.1.7-py39_0.tar.bz2
```